### PR TITLE
Downgrade brace style to warning only

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
   }
 ] 
 1. <a href="http://eslint.org/docs/rules/brace-style.html" target="_blank">brace-style</a>: [
-  "error",
+  "warn",
   "stroustrup"
 ] 
 1. <a href="http://eslint.org/docs/rules/callback-return.html" target="_blank">callback-return</a>: [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,11 @@
 module.exports = {
+    extends: [
+        'plugin:flowtype/recommended'
+    ],
     plugins: [
         'chasevida',
-        'hapi'
+        'hapi',
+        'flowtype'
     ],
     env: {
         browser: true,
@@ -23,7 +27,7 @@ module.exports = {
         'array-bracket-spacing': ['error', 'never'],
         'arrow-parens': ['error', 'always'],
         'arrow-spacing': ['error', { 'before': true, 'after': true }],
-        'brace-style': ['error', 'stroustrup'],
+        'brace-style': ['warn', 'stroustrup'],
         'callback-return': ['error', ['callback', 'next']],
         'camelcase': 'error',
         'chasevida/spaces-in-parens': ['warn', 'never', { 'exceptions': ['!'] }],


### PR DESCRIPTION
I've recently been running into several spots where the brace style will throw errors with new ES6 style destructuring/imports and inline functions.

Downgrading this lets people know about it and make a reasonable choice within the context.

/cc @colensobbdo/core 