### PR TITLE
Downgrade consistent-return to warning only

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,12 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
   "error",
   "never"
 ] 
-1. <a href="http://eslint.org/docs/rules/consistent-return.html" target="_blank">consistent-return</a>: "error" 
+1. <a href="http://eslint.org/docs/rules/consistent-return.html" target="_blank">consistent-return</a>: [
+  "warn",
+  {
+    "treatUndefinedAsUnspecified": true
+  }
+] 
 1. <a href="http://eslint.org/docs/rules/consistent-this.html" target="_blank">consistent-this</a>: [
   "error",
   "self"

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ module.exports = {
         'chasevida/spaces-in-parens': ['warn', 'never', { 'exceptions': ['!'] }],
         'comma-dangle': ['error', 'never'],
         'computed-property-spacing': ['error', 'never'],
-        'consistent-return': 'error',
+        'consistent-return': ['warn', { 'treatUndefinedAsUnspecified': true }],
         'consistent-this': ['error', 'self'],
         'constructor-super': 'error',
         'curly': ['error', 'all'],


### PR DESCRIPTION
There are some cases when also using Flowjs that you will get consistent-return errors when returning void|undefined with optional return types. i.e.

```
var someFunc = (obj: Object): ?User => {

  if (obj.type === 'USER') {
    return new USER()
  }
  return null
}
```

Downgrading the rule allows for this.