### PR TITLE
Downgrade new-cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
   "warn",
   4
 ] 
-1. <a href="http://eslint.org/docs/rules/new-cap.html" target="_blank">new-cap</a>: "error" 
+1. <a href="http://eslint.org/docs/rules/new-cap.html" target="_blank">new-cap</a>: [
+  "warn",
+  {
+    "properties": true
+  }
+] 
 1. <a href="http://eslint.org/docs/rules/new-parens.html" target="_blank">new-parens</a>: "error" 
 1. <a href="http://eslint.org/docs/rules/newline-after-var.html" target="_blank">newline-after-var</a>: "off" 
 1. <a href="http://eslint.org/docs/rules/no-array-constructor.html" target="_blank">no-array-constructor</a>: "error" 

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ module.exports = {
         'max-depth': ['error', 5],
         'max-nested-callbacks': ['error', 3],
         'max-params': ['warn', 4],
-        'new-cap': 'error',
+        'new-cap': ['warn', { 'properties': true }],
         'new-parens': 'error',
         'newline-after-var': 'off',
         'no-array-constructor': 'error',


### PR DESCRIPTION
While the `new-cap` rule is cool if the libs and frameworks you use all play along like they do with Node.js Hapi development, it's not so much the case with other libs.

I'm not really sure this rule is even needed but I propose at least downgrading it.