### PR TITLE
Add spaces for object-curly-spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
 1. <a href="http://eslint.org/docs/rules/no-with.html" target="_blank">no-with</a>: "error" 
 1. <a href="http://eslint.org/docs/rules/object-curly-spacing.html" target="_blank">object-curly-spacing</a>: [
   "error",
-  "never"
+  "always"
 ] 
 1. <a href="http://eslint.org/docs/rules/object-shorthand.html" target="_blank">object-shorthand</a>: "warn" 
 1. <a href="http://eslint.org/docs/rules/one-var.html" target="_blank">one-var</a>: "off" 

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,7 @@ module.exports = {
         'no-use-before-define': ['warn', 'nofunc'],
         'no-useless-call': 'warn',
         'no-with': 'error',
-        'object-curly-spacing': ['error', 'never'],
+        'object-curly-spacing': ['error', 'always'],
         'object-shorthand': 'warn',
         'one-var': 'off',
         'quotes': ['error', 'single', 'avoid-escape'],


### PR DESCRIPTION
Add spaces for `object-curly-spacing` i.e. `const { store } = this.props`.

This is more in alignment with React style programming and may suit us better moving forward.

/cc @colensobbdo/core 