### PR TITLE
feat(react): add eslint plugin to lint react/jsx specific styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
   "avoid-escape"
 ] 
 1. <a href="http://eslint.org/docs/rules/radix.html" target="_blank">radix</a>: "error" 
+1. <a href="http://eslint.org/docs/rules/react/jsx-uses-react.html" target="_blank">react/jsx-uses-react</a>: "error" 
+1. <a href="http://eslint.org/docs/rules/react/jsx-uses-vars.html" target="_blank">react/jsx-uses-vars</a>: "error" 
 1. <a href="http://eslint.org/docs/rules/semi.html" target="_blank">semi</a>: [
   "warn",
   "never"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 module.exports = {
     plugins: [
         'chasevida',
-        'hapi'
+        'hapi',
+        'react'
     ],
     env: {
         browser: true,
@@ -37,11 +38,11 @@ module.exports = {
         'eol-last': 'warn',
         'eqeqeq': 'error',
         'func-style': ['error', 'expression'],
-        'generator-star-spacing': ['error', {"before": true, "after": false}],
+        'generator-star-spacing': ['error', {'before': true, 'after': false}],
         'global-strict': 'off',
         'handle-callback-err': ['error', 'err'],
-        "hapi/hapi-capitalize-modules": 'warn',
-        "hapi/no-arrowception": 'warn',
+        'hapi/hapi-capitalize-modules': 'warn',
+        'hapi/no-arrowception': 'warn',
         'indent': ['error', 4],
         'key-spacing': 'error',
         'max-depth': ['error', 5],
@@ -91,6 +92,8 @@ module.exports = {
         'one-var': 'off',
         'quotes': ['error', 'single', 'avoid-escape'],
         'radix': 'error',
+        'react/jsx-uses-react': 'error',
+        'react/jsx-uses-vars': 'error',
         'semi': ['warn', 'never'],
         'sort-vars': 'off',
         'keyword-spacing': 'error',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "eslint-plugin-chasevida": "^0.1.2",
     "eslint-plugin-hapi": "^4.0.0",
+    "eslint-plugin-react": "^6.9.0"
+  },
+  "devDependencies": {
     "rimraf": "^2.5.4"
   },
   "keywords": [


### PR DESCRIPTION
Add rules to make sure eslint checks that React has been included when JSX is used.