### PR TITLE
Add allowTemplateLiterals to quotes rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Changes that are breaking e.g. upgrading from a warning to an exception should b
 1. <a href="http://eslint.org/docs/rules/quotes.html" target="_blank">quotes</a>: [
   "error",
   "single",
-  "avoid-escape"
+  "avoid-escape",
+  {
+    "allowTemplateLiterals": true
+  }
 ] 
 1. <a href="http://eslint.org/docs/rules/radix.html" target="_blank">radix</a>: "error" 
 1. <a href="http://eslint.org/docs/rules/semi.html" target="_blank">semi</a>: [

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ module.exports = {
         'object-curly-spacing': ['error', 'never'],
         'object-shorthand': 'warn',
         'one-var': 'off',
-        'quotes': ['error', 'single', 'avoid-escape'],
+        'quotes': ['error', 'single', 'avoid-escape', { 'allowTemplateLiterals': true }],
         'radix': 'error',
         'semi': ['warn', 'never'],
         'sort-vars': 'off',


### PR DESCRIPTION
Simply adds the option to `allowTemplateLiterals` with quotes.

/cc @colensobbdo/core 